### PR TITLE
test(add-missing-tests): add the missing tests to improve code coverage

### DIFF
--- a/src/main/java/io/apimatic/okhttpclient/adapter/OkClient.java
+++ b/src/main/java/io/apimatic/okhttpclient/adapter/OkClient.java
@@ -510,6 +510,9 @@ public class OkClient implements HttpClient {
                 wrapperHeadersBuilder.add("Content-Disposition", "form-data; name="
                         + appendQuotedStringAndEncodeEscapeCharacters(param.getKey()));
                 multipartBuilder.addPart(wrapperHeadersBuilder.build(), body);
+            } else {
+                multipartBuilder.addFormDataPart(param.getKey(),
+                        (param.getValue() == null) ? "" : param.getValue().toString());
             }
         }
         return multipartBuilder.build();

--- a/src/main/java/io/apimatic/okhttpclient/adapter/OkClient.java
+++ b/src/main/java/io/apimatic/okhttpclient/adapter/OkClient.java
@@ -510,9 +510,6 @@ public class OkClient implements HttpClient {
                 wrapperHeadersBuilder.add("Content-Disposition", "form-data; name="
                         + appendQuotedStringAndEncodeEscapeCharacters(param.getKey()));
                 multipartBuilder.addPart(wrapperHeadersBuilder.build(), body);
-            } else {
-                multipartBuilder.addFormDataPart(param.getKey(),
-                        (param.getValue() == null) ? "" : param.getValue().toString());
             }
         }
         return multipartBuilder.build();

--- a/src/test/java/apimatic/okhttpclient/adapter/OkClientTest.java
+++ b/src/test/java/apimatic/okhttpclient/adapter/OkClientTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/src/test/java/apimatic/okhttpclient/adapter/OkClientTest.java
+++ b/src/test/java/apimatic/okhttpclient/adapter/OkClientTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -34,17 +35,20 @@ import io.apimatic.coreinterfaces.http.request.MultipartFile;
 import io.apimatic.coreinterfaces.http.request.configuration.CoreEndpointConfiguration;
 import io.apimatic.coreinterfaces.http.request.configuration.RetryOption;
 import io.apimatic.coreinterfaces.http.response.Response;
+import io.apimatic.coreinterfaces.logger.ApiLogger;
 import io.apimatic.coreinterfaces.type.CoreFileWrapper;
 import io.apimatic.okhttpclient.adapter.OkClient;
 
 public class OkClientTest extends OkHttpClientMock {
-
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
 
     @Mock
     private ClientConfiguration clientConfiguration;
+
+    @Mock
+    private ApiLogger apiLogger;
 
     @Mock
     private Response coreHttpResponse;
@@ -84,6 +88,7 @@ public class OkClientTest extends OkHttpClientMock {
         assertNotNull(client);
     }
 
+    @SuppressWarnings("static-access")
     @Test
     public void testshutDown() {
         OkClient client = new OkClient(clientConfiguration, compatibilityFactory);
@@ -250,7 +255,79 @@ public class OkClientTest extends OkHttpClientMock {
         assertEquals(actual, expected);
     }
 
+    @Test
+    public void testRequestWithNoRetries() throws IOException {
+        when(clientConfiguration.getNumberOfRetries()).thenReturn(-1);
+        when(clientConfiguration.getHttpClientInstance()).thenReturn(client);
+        when(clientConfiguration.shouldOverrideHttpClientConfigurations()).thenReturn(true);
+        when(client.newCall(any(okhttp3.Request.class))).thenReturn(call);
 
+        OkClient client = new OkClient(clientConfiguration, compatibilityFactory);
+        when(coreHttpRequest.getHttpMethod()).thenReturn(Method.POST);
+        when(coreHttpRequest.getBody()).thenReturn("bodyValue");
+
+
+        when(call.execute()).thenReturn(okHttpResponse);
+        when(okHttpResponse.body()).thenReturn(okHttpResponseBody);
+        String serverResponseString = "Get Response";
+        when(coreHttpResponse.getBody()).thenReturn(serverResponseString);
+        when(okHttpResponseBody.string()).thenReturn(serverResponseString);
+        when(okHttpResponse.code()).thenReturn(200);
+
+        when(compatibilityFactory.createHttpResponse(anyInt(), any(HttpHeaders.class),
+                any(InputStream.class), anyString())).thenReturn(coreHttpResponse);
+
+        Response coreHttpResponse = client.execute(coreHttpRequest, configuration);
+        String expected = serverResponseString;
+        String actual = coreHttpResponse.getBody();
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testExecuteRequestWithLogging() throws IOException {
+        when(clientConfiguration.getNumberOfRetries()).thenReturn(-1);
+        when(clientConfiguration.getHttpClientInstance()).thenReturn(client);
+        when(clientConfiguration.shouldOverrideHttpClientConfigurations()).thenReturn(true);
+        when(client.newCall(any(okhttp3.Request.class))).thenReturn(call);
+
+        OkClient client = new OkClient(clientConfiguration, compatibilityFactory, apiLogger);
+        when(coreHttpRequest.getHttpMethod()).thenReturn(Method.POST);
+        when(coreHttpRequest.getBody()).thenReturn("bodyValue");
+
+
+        when(call.execute()).thenReturn(okHttpResponse);
+        when(okHttpResponse.body()).thenReturn(okHttpResponseBody);
+        String serverResponseString = "Get Response";
+        when(coreHttpResponse.getBody()).thenReturn(serverResponseString);
+        when(okHttpResponseBody.string()).thenReturn(serverResponseString);
+        when(okHttpResponse.code()).thenReturn(200);
+
+        when(compatibilityFactory.createHttpResponse(anyInt(), any(HttpHeaders.class),
+                any(InputStream.class), anyString())).thenReturn(coreHttpResponse);
+
+        Response coreHttpResponse = client.execute(coreHttpRequest, configuration);
+        String expected = serverResponseString;
+        String actual = coreHttpResponse.getBody();
+        assertEquals(actual, expected);
+    }
+
+    @Test(expected = IOException.class)
+    public void testExecuteRequestWithLogging1() throws IOException {
+        IOException ioException = new IOException("Connection Error");
+        
+        when(clientConfiguration.getNumberOfRetries()).thenReturn(-1);
+        when(clientConfiguration.getHttpClientInstance()).thenReturn(client);
+        when(clientConfiguration.shouldOverrideHttpClientConfigurations()).thenReturn(true);
+        when(client.newCall(any(okhttp3.Request.class))).thenReturn(call);
+
+        OkClient client = new OkClient(clientConfiguration, compatibilityFactory, apiLogger);
+        when(coreHttpRequest.getHttpMethod()).thenReturn(Method.POST);
+        when(coreHttpRequest.getBody()).thenReturn("bodyValue");
+        when(call.execute()).thenThrow(ioException);
+        
+        client.execute(coreHttpRequest, configuration);
+    }
+    
     @Test
     public void testPostMultipartFileWrapperRequest() throws IOException {
         when(clientConfiguration.getHttpClientInstance()).thenReturn(client);

--- a/src/test/java/apimatic/okhttpclient/adapter/OkClientTest.java
+++ b/src/test/java/apimatic/okhttpclient/adapter/OkClientTest.java
@@ -428,6 +428,39 @@ public class OkClientTest extends OkHttpClientMock {
         String actual = coreHttpResponse.getBody();
         assertEquals(actual, expected);
     }
+    
+
+    @Test
+    public void testSimpleObjectWithMultiPart() throws IOException {
+        when(clientConfiguration.getHttpClientInstance()).thenReturn(client);
+        when(clientConfiguration.shouldOverrideHttpClientConfigurations()).thenReturn(true);
+        when(client.newCall(any(okhttp3.Request.class))).thenReturn(call);
+
+        OkClient client = new OkClient(clientConfiguration, compatibilityFactory);
+        when(coreHttpRequest.getHttpMethod()).thenReturn(Method.POST);
+
+        List<SimpleEntry<String, Object>> listP = new ArrayList<>();
+        listP.add(new SimpleEntry<String, Object>("fileWrapper", coreMultipartWrapper));
+        listP.add(new SimpleEntry<String, Object>("simple object", "object"));
+
+        String serverResponseString = "object";
+      
+        when(coreHttpRequest.getParameters()).thenReturn(listP);
+
+        when(call.execute()).thenReturn(okHttpResponse);
+        when(okHttpResponse.body()).thenReturn(okHttpResponseBody);
+        when(coreHttpResponse.getBody()).thenReturn(serverResponseString);
+        when(okHttpResponseBody.string()).thenReturn(serverResponseString);
+        when(okHttpResponse.code()).thenReturn(200);
+
+        when(compatibilityFactory.createHttpResponse(anyInt(), any(HttpHeaders.class),
+                any(InputStream.class), anyString())).thenReturn(coreHttpResponse);
+
+        Response coreHttpResponse = client.execute(coreHttpRequest, configuration);
+        String expected = serverResponseString;
+        String actual = coreHttpResponse.getBody();
+        assertEquals(actual, expected);
+    }
 
     @Test
     public void testPostFormParametersRequest() throws IOException {

--- a/src/test/java/apimatic/okhttpclient/adapter/RetryInterceptorTest.java
+++ b/src/test/java/apimatic/okhttpclient/adapter/RetryInterceptorTest.java
@@ -1,9 +1,11 @@
 package apimatic.okhttpclient.adapter;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Before;
@@ -13,12 +15,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import apimatic.okhttpclient.adapter.mocks.CompatibilityFactoryMock;
+import io.apimatic.coreinterfaces.compatibility.CompatibilityFactory;
 import io.apimatic.coreinterfaces.http.ClientConfiguration;
 import io.apimatic.coreinterfaces.http.Method;
 import io.apimatic.coreinterfaces.http.request.configuration.CoreEndpointConfiguration;
 import io.apimatic.coreinterfaces.http.request.configuration.RetryOption;
 import io.apimatic.coreinterfaces.logger.ApiLogger;
 import io.apimatic.okhttpclient.adapter.interceptors.RetryInterceptor;
+import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor.Chain;
 import okhttp3.Request;
@@ -34,12 +38,18 @@ public class RetryInterceptorTest extends CompatibilityFactoryMock {
 
     @Mock
     private Request request;
+    
+    @Mock
+    private CompatibilityFactory compatibilityFactory;
 
     @Mock
     private CoreEndpointConfiguration endpointConfiguration;
 
     @Mock
     private ApiLogger apiLogger;
+    
+    @Mock
+    private Headers headers;
 
     @Mock
     private Response response;
@@ -109,6 +119,7 @@ public class RetryInterceptorTest extends CompatibilityFactoryMock {
         when(clientConfiguration.getNumberOfRetries()).thenReturn(3);
         when(request.method()).thenReturn(Method.GET.toString());
         when(response.header("Retry-After")).thenReturn("3");
+        when(response.headers()).thenReturn(headers);
         when(request.url()).thenReturn(url);
         RetryInterceptor interceptor = new RetryInterceptor(clientConfiguration, apiLogger);
         interceptor.addRequestEntry(request, endpointConfiguration, null);
@@ -164,5 +175,8 @@ public class RetryInterceptorTest extends CompatibilityFactoryMock {
         when(clientConfiguration.getBackOffFactor()).thenReturn(2);
         when(clientConfiguration.getMaximumRetryWaitTime()).thenReturn(6l);
         when(endpointConfiguration.getRetryOption()).thenReturn(RetryOption.DEFAULT);
+        when(headers.toMultimap()).thenReturn(Collections.EMPTY_MAP);
+        when(compatibilityFactory.createHttpHeaders(anyMap())).thenReturn(httpHeaders);
+     
     }
 }


### PR DESCRIPTION
OkHttp-client-adapter is responsible for making client request to the server. This should be error-free and should work fine and smoothly. So, added the missing tests to improve the code coverage.

closes #5