### PR TITLE
ci(add-code-coverage-ci-script): script to upload the code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,14 @@
-name: Update the Code Coverage
+name: Publish Test Coverage Report
 
 on:
-  workflow_dispatch
+  push:
+    branches: [ "main" ]
 
 jobs:
-  coverage:
+  publish-code-coverage-report:
     name: JAVA 
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.head_commit.message), 'skip ci')"
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Update the Code Coverage
+
+on:
+  workflow_dispatch
+
+jobs:
+  coverage:
+    name: JAVA 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+    - name: Upload coverage report
+      uses: paambaati/codeclimate-action@v3.2.0
+      env:
+        # Set CC_TEST_REPORTER_ID as secret of your repo
+        CC_TEST_REPORTER_ID: ${{secrets.CODE_CLIMATE_TEST_REPORTER_ID}}
+        JACOCO_SOURCE_PATH: "${{github.workspace}}/src/main/java"
+      with:
+        # The report file must be there, otherwise Code Climate won't find it
+        coverageCommand: mvn test
+        coverageLocations: ${{github.workspace}}/target/site/jacoco/jacoco.xml:jacoco

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>io.apimatic</groupId>
@@ -175,6 +173,25 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.5</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.9.1</version>
@@ -219,7 +236,7 @@
 			</plugin>
 		</plugins>
 	</reporting>
-	
+
 	<licenses>
 		<license>
 			<name>APIMATIC REFERENCE SOURCE LICENSE</name>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
 			<version>4.10.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>0.8.5</version>
+		</dependency>
+		<dependency>
 			<groupId>io.apimatic</groupId>
 			<artifactId>core-interfaces</artifactId>
 			<version>[0.1, 0.2)</version>


### PR DESCRIPTION
Code climate tells you the key metrics of your code. Added the CI script to upload the coverage on code climate which will later be used for badges.

closes #15