### PR TITLE
ci(linter-configurations): configure linter for the project

### DIFF
--- a/.github/linters/checkstyle.xml
+++ b/.github/linters/checkstyle.xml
@@ -71,6 +71,7 @@
   <!-- See https://checkstyle.org/config_sizes.html -->
   <module name="FileLength"/>
   <module name="LineLength">
+    <property name="max" value="100"/>
     <property name="fileExtensions" value="java"/>
   </module>
 

--- a/.github/linters/checkstyle.xml
+++ b/.github/linters/checkstyle.xml
@@ -148,7 +148,13 @@
     <module name="ParenPad"/>
     <module name="TypecastParenPad"/>
     <module name="WhitespaceAfter"/>
-    <module name="WhitespaceAround"/>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyCatches" value="true"/>
+    </module>
+        
+
 
     <!-- Modifier Checks                                    -->
     <!-- See https://checkstyle.org/config_modifiers.html -->

--- a/.github/linters/checkstyle.xml
+++ b/.github/linters/checkstyle.xml
@@ -173,7 +173,9 @@
     <!-- See https://checkstyle.org/config_coding.html -->
     <module name="EmptyStatement"/>
     <module name="EqualsHashCode"/>
-    <module name="HiddenField"/>
+    <module name="HiddenField">
+      <property name="tokens" value="VARIABLE_DEF"/>
+    </module>
     <module name="IllegalInstantiation"/>
     <module name="InnerAssignment"/>
     <module name="MagicNumber"/>

--- a/.github/linters/checkstyle.xml
+++ b/.github/linters/checkstyle.xml
@@ -193,7 +193,10 @@
     <!-- Miscellaneous other checks.                   -->
     <!-- See https://checkstyle.org/config_misc.html -->
     <module name="ArrayTypeStyle"/>
-    <module name="FinalParameters"/>
+    <module name="FinalParameters">
+      <property name="tokens" value="CTOR_DEF"/>
+      <property name="ignorePrimitiveTypes" value="true"/>
+    </module>
     <module name="TodoComment"/>
     <module name="UpperEll"/>
 


### PR DESCRIPTION
The line length of characters rule was set to 80 characters but now I changed it to 100 characters.  All our java code followed the 100 characters per line rule. So, the linter must check the code with 100 characters per line.

For reference see this [article](https://checkstyle.org/config_sizes.html#LineLength).

closes #17