### PR TITLE
fix(push-in-protected-branch): push in the protected branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release To Maven Central
 
-# Release to Maven Central
+# Run workflow on commits to the `main` branch
 on:
    workflow_dispatch:
     inputs:
@@ -42,16 +42,21 @@ jobs:
         uses: devops-infra/action-commit-push@master
         with:
            github_token: "${{ secrets.GITHUB_TOKEN }}"
-           add_timestamp: true
            commit_message: "ci(release-version): update pom.xml [ci skip]"
            force: false
-           target_branch: ${{ github.ref }}
-      - name: Push the version change
+           target_branch: project-version-update
+      - name: Push the version changes
         if: steps.release.outputs.exit_code == 0
-        uses: ad-m/github-push-action@master
+        uses: CasperWA/push-protected@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+           token: ${{ secrets.TOKEN_GITHUB }}
+           branch: main
+      - name: Delete the intermediate branch
+        if: steps.release.outputs.exit_code == 0
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{github.token}}
+          branches: project-version-update
       - name: Create tag
         if: steps.release.outputs.exit_code == 0
         id: tag_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,11 @@ jobs:
            commit_message: "ci(release-version): update pom.xml [ci skip]"
            force: false
            target_branch: project-version-update
-      - name: Push the version changes
+      - name: Push the version change
         if: steps.release.outputs.exit_code == 0
         uses: CasperWA/push-protected@v2
         with:
-           token: ${{ secrets.TOKEN_GITHUB }}
+           token: ${{ secrets.PAT }}
            branch: main
       - name: Delete the intermediate branch
         if: steps.release.outputs.exit_code == 0


### PR DESCRIPTION
Release action to push to a GitHub-protected branch, you need to pass a personal access token (PAT), preferably as a secret, to the token input.  And delete the intermediate branch at the end.

closes #29