### PR TITLE
fix(create-tag-using-pat): create tag using the personal access token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT }}
           custom_tag: ${{ github.event.inputs.Version }}
           tag_prefix: ""
           


### PR DESCRIPTION
To bypass the protection of tags used the personal access token for the creation of release tags.

closes #31