### PR TITLE
build(package): update referred packages to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.apimatic</groupId>
 	<artifactId>okhttp-client-adapter</artifactId>
-	<version>0.1.4</version>
+	<version>0.1.5</version>
 
 	<name>okhttp-client-adapter</name>
 	<description>An adapter for okhttp-client library consumed by the SDKs generated with APIMatic.</description>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
-			<version>0.8.5</version>
+			<version>0.8.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -68,13 +68,13 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>4.7.0</version>
+			<version>4.11.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
-			<version>4.7.0</version>
+			<version>4.11.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The following PR updates the referred external packages in the **okhttp-client-adapter** to make sure it is up-to-date and has the latest fixes and improvements.

The following PR also bumps the patch version for the release.

The updated packages are:
- org.mockito > mockito-core
- org.mockito > mockito-inline
- org.jacoco > jacoco-maven-plugin