### PR TITLE
feat(okhttp): enable retryOnConnectionFailure

### DIFF
--- a/src/main/java/io/apimatic/okhttpclient/adapter/OkClient.java
+++ b/src/main/java/io/apimatic/okhttpclient/adapter/OkClient.java
@@ -173,7 +173,7 @@ public class OkClient implements HttpClient {
             synchronized (SYNC_OBJECT) {
                 if (defaultOkHttpClient == null) {
                     defaultOkHttpClient =
-                            new OkHttpClient.Builder().retryOnConnectionFailure(false)
+                            new OkHttpClient.Builder().retryOnConnectionFailure(true)
                                     .callTimeout(0, TimeUnit.SECONDS).build();
                 }
             }


### PR DESCRIPTION
Enable `retryOnConnectionFailure(true)` in the OkHttp client configuration to improve resilience against transient network failures. Ensures that failed connections are retried automatically.

## What
- Enabled retryOnConnectionFailure(true) in the OkHttp client configuration.
- This ensures that failed connections due to transient issues (e.g., timeouts, connection resets) are retried automatically.

## Why
- By default, OkHttp has retryOnConnectionFailure enabled, but ensuring it explicitly avoids accidental changes in behavior if default settings change in future versions.
- Helps improve resilience in network communication by retrying failed connections without manual intervention.
- Reduces intermittent failures caused by temporary network disruptions.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)
